### PR TITLE
fix `&gt:` in VirtGraphProtocolCURLExamples.txt

### DIFF
--- a/wikis/VOS/text/VirtGraphProtocolCURLExamples.txt
+++ b/wikis/VOS/text/VirtGraphProtocolCURLExamples.txt
@@ -80,7 +80,7 @@ WHERE
 
 ---++++ HTTP GET Example
 
-   1 Load the sample data to a named graph identified by the IRI &lt;urn:graph:update:test:get&gt:
+   1 Load the sample data to a named graph identified by the IRI &lt;urn:graph:update:test:get&gt;:
 <verbatim>
 curl --digest --user dba:dba --verbose --url "http://example.com/sparql-graph-crud-auth?graph-uri=urn:graph:update:test:get" -T books.ttl 
 </verbatim>
@@ -116,7 +116,7 @@ ns1:book2       ns0:price       23 ;
 
 ---++++ HTTP DELETE Example
 
-   1 Load the sample data to a named graph identified by the IRI &lt;urn:graph:update:test:delete&gt:
+   1 Load the sample data to a named graph identified by the IRI &lt;urn:graph:update:test:delete&gt;:
 <verbatim>
 curl --digest --user dba:dba --verbose --url "http://example.com/sparql-graph-crud-auth?graph-uri=urn:graph:update:test:delete" -T books.ttl 
 </verbatim>
@@ -169,7 +169,7 @@ WHERE
 
 ---++++ HTTP POST Example
 
-   1 Load the sample data to a named graph identified by the IRI &lt;urn:graph:update:test:post&gt:
+   1 Load the sample data to a named graph identified by the IRI &lt;urn:graph:update:test:post&gt;:
 <verbatim>
 curl --digest --user dba:dba --verbose --url "http://example.com/sparql-graph-crud-auth?graph-uri=urn:graph:update:test:post" -X POST -T books.ttl
 


### PR DESCRIPTION
broken entity is actually `&gt` as the `:` is intended punctuation for the text where the URI falls