### PR TITLE
Fix `XAnyNormalization`-related typos in dbadm.xml

### DIFF
--- a/virtuoso-docs-source/xmlsource/dbadm.xml
+++ b/virtuoso-docs-source/xmlsource/dbadm.xml
@@ -1876,28 +1876,28 @@ impractical in all cases.
               <itemizedlist>
                 <listitem xml:id="ini_i18n_xanynormalization">
                   <formalpara>
-                    <title>WideFileNames = 1/2/3/0</title>
-                    <para>0: default value. It means not to normalize anything, so for ex.
+                    <title>XAnyNormalization = 1/2/3/0</title>
+                    <para>0: default value. It means not to normalize anything, so, for example,
                         	"José" and "Jose" are two distinct words.
+                    <tip><title>See Also:</title><para><link linkend="virtuosotipsandtrickscontrolunicode3">How Can I Control the normalization of UNICODE3 accented chars in free-text index?</link></para></tip></para>
+                  </formalpara>
+                  <para>1: Any pair of base char and combining char (NSM, non-spacing
+modifier) is replaced with a single combined char, so if character "é" is written as a sequence
+of "base" character "e" and a unicode char U+0301 ("combining acute accent"), then the pair will
+be replaced with a single U+00E9 ("latin small letter e acute").
+</para>
+                  <para>2: Any combined char is converted to its (smallest known) base, so,
+"é" will lose its accent and become plain old ASCII "e".
+</para>
+                  <para>3: This is equal to 1+2, and when set, both conversions are performed.
+As a result, any pair of base char and combining char loses its second char, and any chars with accents will lose
+accents.</para>
+                  <para>If the parameter is required at all, the needed value is probably 3, 
+so the fragment of virtuoso.ini should be:</para>
                     <programlisting>
 [I18N]
 XAnyNormalization=3
 </programlisting>
-                    <tip><title>See Also:</title><para><link linkend="virtuosotipsandtrickscontrolunicode3">How Can I Control the normalization of UNICODE3 accented chars in free-text index?</link></para></tip></para>
-                  </formalpara>
-                  <para>1: Any pair of base char and combinig char (NSM, non-spacing
-modifier) is replaced with a single combined char, so if character "é" is written as a sequence
-of "base" character "e" and a unicode char U +301 ("combining acute accent") then the pair will
-be replaced with single U+00E9 ("latin small letter e acute").
-</para>
-                  <para>2: Any combined char is converted to its (smallest known) base. So
-"é" will lose its accent and become plain old ASCII "e".
-</para>
-                  <para>3: This is equl to 1|2 and when set then performs both conversions.
-As a result, pair of base char and combinig char loses its second char and chars with accents will lose
-accents.</para>
-                  <para>If the parameter is required at all, the needed value is probably 3.
-So the fragment of virtuoso.ini should be:</para>
                 </listitem>
                 <listitem xml:id="ini_i18n_widefilenames">
                   <formalpara>


### PR DESCRIPTION
As flagged in https://github.com/openlink/virtuoso-opensource/pull/1004#issuecomment-1021495575